### PR TITLE
Refactor: Rename env-sync to env-twin across codebase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ function parseArgs(): CliOptions {
 function printUsage() {
   console.log(
     `
-Usage: env-sync [options]
+Usage: env-twin [options]
 
 Options:
   --source, --src       Source .env file path (default: .env)
@@ -78,7 +78,7 @@ Options:
   --version, -v         Display version information
 
 Example:
-  env-sync --src .env.development --destination .env.dev.example
+  env-twin --src .env.development --destination .env.dev.example
 `
   );
 }
@@ -108,7 +108,7 @@ try {
 
   // Handle --version flag
   if (params.version) {
-    console.log(`env-sync version ${getVersion()}`);
+    console.log(`env-twin version ${getVersion()}`);
     process.exit(0);
   }
 


### PR DESCRIPTION
I've replaced all occurrences of 'env-sync' with 'env-twin' in your project files, including the README, package.json, and source code.

- I updated help messages and version information in `src/index.ts`.
- I verified that `README.md`, `package.json`, and `src/index.test.ts` were already up-to-date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all user-facing references of the CLI tool name from "env-sync" to "env-twin" in usage instructions and version output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->