### PR TITLE
Fix: Address shellcheck warnings and remove redundant step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Run tests
         run: bun test
 
-      - name: Install Changesets CLI
-        run: bun add -D @changesets/cli
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/install_bun.sh
+++ b/install_bun.sh
@@ -42,15 +42,15 @@ error() {
 }
 
 info() {
-    echo -e "${Dim}$@ ${Color_Off}"
+  printf '%b\n' "${Dim}$*${Color_Off}"
 }
 
 info_bold() {
-    echo -e "${Bold_White}$@ ${Color_Off}"
+  printf '%b\n' "${Bold_White}$*${Color_Off}"
 }
 
 success() {
-    echo -e "${Green}$@ ${Color_Off}"
+  printf '%b\n' "${Green}$*${Color_Off}"
 }
 
 command -v unzip >/dev/null ||


### PR DESCRIPTION
This commit addresses several issues:

- Removed a redundant step in the GitHub Actions workflow (`.github/workflows/npm-publish.yml`) that reinstalled `@changesets/cli`. This dependency is already in `package.json`.
- Updated `install_bun.sh` to replace `echo -e` with `printf` in the `info_bold`, `success`, and `info` functions. This resolves shellcheck SC2145 warnings and improves script portability and robustness by ensuring arguments are handled as a single string.