### PR TITLE
test: add version information test and simplify version lookup

### DIFF
--- a/.changeset/all-cooks-divide.md
+++ b/.changeset/all-cooks-divide.md
@@ -1,0 +1,5 @@
+---
+'env-twin': patch
+---
+
+add version information test and simplify version lookup

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -129,4 +129,12 @@ TEST_VAR="input_test_var"
       );
     }).toThrow();
   });
+
+  test('should display version information', () => {
+    const output = execSync(`bun ${path.join(__dirname, 'index.ts')} --version`).toString();
+    const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    const expectedVersion = packageJson.version || 'unknown';
+    expect(output).toContain(`env-twin version ${expectedVersion}`);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,17 +85,14 @@ Example:
 
 // Get package version from package.json
 function getVersion(): string {
-  try {
-    // Use import.meta.url to get the current module's URL
-    const currentDir = path.dirname(new URL(import.meta.url).pathname);
-    // Navigate to the package.json file
-    const packagePath = path.resolve(currentDir, 'package.json');
-    const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));
-    return packageJson.version || 'unknown';
-  } catch (error) {
-    return '1.0.0'; // Fallback version
+    try {
+      const packagePath = path.resolve(process.cwd(), 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));
+      return packageJson.version || 'unknown';
+    } catch (error) {
+      return '1.0.0';
+    }
   }
-}
 
 try {
   const params = parseArgs();


### PR DESCRIPTION
Simplify version lookup by using process.cwd() instead of import.meta.url and add corresponding test case to verify version information display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a test to verify that the CLI displays version information correctly when using the --version flag.

- **Bug Fixes**
  - Improved version lookup logic to ensure version information is accurately retrieved from the current working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->