### PR TITLE
🛡️ Sentinel: Fix insecure file permissions during sync

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Arbitrary File Overwrite via Symbolic Links (CWE-59) in `FileRestorer` and `restoreBackup`.
 **Learning:** Checking `fs.existsSync` follows symlinks, so it returns true for a symlink pointing to an existing file. Writing to this path overwrites the target file (e.g., `/etc/passwd`) instead of replacing the symlink.
 **Prevention:** Use `fs.lstatSync` to check if the target is a symbolic link. If so, unlink it (`fs.unlinkSync`) before writing the restored file to ensure the operation only affects the intended path.
+
+## 2026-01-27 - Atomic Write Permission Regression
+**Vulnerability:** Insecure File Permissions (CWE-276) in `sync` command.
+**Learning:** Atomic file updates (write temp + rename) reset file permissions to defaults because `rename` preserves the source (temp) file's mode, losing the original target's mode.
+**Prevention:** Always read `fs.stat(target).mode` before atomic update and apply it to the temp file creation using `{ mode: originalMode }`.


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

**Vulnerability:** Insecure File Permissions (CWE-276)
**Severity:** HIGH
**Description:**
The `sync` command used an atomic write strategy (write to `.tmp` + rename) that failed to preserve the original file's permissions. This meant that a secure `.env` file (e.g., `0o600`) would be replaced by a new file with default permissions (e.g., `0o644` or `0o666`), potentially exposing secrets to other users on the system.

**Fix:**
- Modified `src/commands/sync.ts` to read the existing file's mode (`fs.statSync().mode`) before writing.
- Applied the original mode to the temporary file creation.
- Added logic to default new sensitive files (`.env*`) to `0o600` (read/write owner only).

**Verification:**
- Verified with a reproduction script that `.env` files retain `0o600` permissions after sync.
- Ran full test suite (`bun test`) to ensure no regressions.


---
*PR created automatically by Jules for task [4225214262063512813](https://jules.google.com/task/4225214262063512813) started by @atssj*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed file permission regression during sync operations. Permissions are now properly preserved when updating files.
  * .env files now default to secure owner-only read/write permissions.

* **Documentation**
  * Added documentation entry for atomic write permission handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->