### PR TITLE
🛡️ Sentinel: Fix Insecure File Permissions in Sync and Restore

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Arbitrary File Overwrite via Symbolic Links (CWE-59) in `FileRestorer` and `restoreBackup`.
 **Learning:** Checking `fs.existsSync` follows symlinks, so it returns true for a symlink pointing to an existing file. Writing to this path overwrites the target file (e.g., `/etc/passwd`) instead of replacing the symlink.
 **Prevention:** Use `fs.lstatSync` to check if the target is a symbolic link. If so, unlink it (`fs.unlinkSync`) before writing the restored file to ensure the operation only affects the intended path.
+
+## 2026-01-28 - Insecure File Permissions via Atomic Writes
+**Vulnerability:** File Permission Reset (CWE-276) in `src/commands/sync.ts`.
+**Learning:** Atomic writes (write temp + rename) replace the target file's metadata with the temp file's. If the temp file is created with default permissions (umask), a previously secure file (0600) becomes insecure (e.g., 0644) after the operation.
+**Prevention:** Before creating a temp file, read the target file's mode (if it exists) and explicitly set the temp file's mode to match. For new sensitive files, default to strict permissions (0600).


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Insecure File Permissions

🚨 Severity: HIGH
💡 Vulnerability: File Permission Reset (CWE-276). When syncing or restoring .env files, the tool used atomic writes (write to temp + rename). This process reset file permissions to system defaults (e.g., 0664), potentially exposing sensitive environment variables if the file was previously secured (0600).
🎯 Impact: Sensitive .env files containing API keys or secrets could become world-readable after a sync operation.
🔧 Fix:
1. In `sync.ts`: Before writing the temporary file, we now check if the target file exists. If so, we copy its mode. If not, and it's a sensitive file (starts with `.env` but not `.env.example`), we default to `0o600`.
2. In `backup.ts`: Applied similar logic to `restoreBackup` utility to preserve permissions or enforce security on restoration.
✅ Verification:
- Created a reproduction script `reproduce_issue.ts` that verified permissions were reset to 0664 before the fix.
- Confirmed that after the fix, permissions are preserved (0600 stays 0600) or securely set for new files.
- Ran full test suite `bun test` to ensure no regressions.

---
*PR created automatically by Jules for task [1564338704496348159](https://jules.google.com/task/1564338704496348159) started by @atssj*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed insecure file permissions vulnerability in sync and backup operations. Sensitive files now receive restrictive default permissions, and existing file permissions are preserved during atomic writes.

* **Documentation**
  * Added security documentation describing file permission handling and prevention guidance for atomic write operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->