### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix permission reset vulnerability in sync command

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Arbitrary File Overwrite via Symbolic Links (CWE-59) in `FileRestorer` and `restoreBackup`.
 **Learning:** Checking `fs.existsSync` follows symlinks, so it returns true for a symlink pointing to an existing file. Writing to this path overwrites the target file (e.g., `/etc/passwd`) instead of replacing the symlink.
 **Prevention:** Use `fs.lstatSync` to check if the target is a symbolic link. If so, unlink it (`fs.unlinkSync`) before writing the restored file to ensure the operation only affects the intended path.
+
+## 2026-01-29 - Insecure Atomic Writes (Permission Reset)
+**Vulnerability:** Permission Reset (CWE-276) during Atomic Write in `sync` command.
+**Learning:** `fs.rename` replaces the target file along with its metadata (permissions). If the temporary file is created with default permissions (usually 0o644), replacing a secured file (0o600) exposes it to other users.
+**Prevention:** Explicitly read the mode of the target file (if it exists) and apply it to the temporary file (`fs.writeFileSync(..., { mode })`) before renaming.

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -265,7 +265,15 @@ export async function runSync(options: {
       // Atomic Write
       const tempPath = `${filePath}.tmp`;
       try {
-          fs.writeFileSync(tempPath, newContent, 'utf-8');
+          // Security: Preserve existing file permissions or default to secure mode
+          let fileMode = 0o644;
+          if (fs.existsSync(filePath)) {
+            fileMode = fs.statSync(filePath).mode;
+          } else if (/^\.env(\.|$)/.test(fileName) && fileName !== '.env.example') {
+            fileMode = 0o600; // Secure default for sensitive files
+          }
+
+          fs.writeFileSync(tempPath, newContent, { encoding: 'utf-8', mode: fileMode });
           fs.renameSync(tempPath, filePath);
           console.log(colors.green(`✓ Updated ${fileName}`));
       } catch (err) {

--- a/tests/permission_test.ts
+++ b/tests/permission_test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test, beforeAll, afterAll, beforeEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+describe('Permission Preservation', () => {
+  const testDir = path.join(__dirname, 'test-perm-temp');
+
+  beforeAll(() => {
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    if (fs.existsSync(testDir)) {
+        fs.rmSync(testDir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(testDir, { recursive: true });
+  });
+
+  test('should preserve file permissions during sync', () => {
+    if (process.platform === 'win32') return; // Permissions are different on Windows
+
+    const envPath = path.join(testDir, '.env');
+    const examplePath = path.join(testDir, '.env.example');
+    const srcPath = path.resolve(__dirname, '../src/index.ts');
+
+    // Create .env with restrictive permissions (0o600)
+    fs.writeFileSync(envPath, 'VAR1=value1\n');
+    fs.chmodSync(envPath, 0o600);
+
+    // Verify initial permissions
+    const initialStats = fs.statSync(envPath);
+    expect(initialStats.mode & 0o777).toBe(0o600);
+
+    // Create .env.example with an extra key to trigger an update
+    fs.writeFileSync(examplePath, 'VAR1=value1\nVAR2=value2\n');
+
+    // Run sync
+    execSync(`bun ${srcPath} sync --yes`, { cwd: testDir });
+
+    // Verify content updated
+    const content = fs.readFileSync(envPath, 'utf-8');
+    expect(content).toContain('VAR2=');
+
+    // Verify permissions preserved
+    const finalStats = fs.statSync(envPath);
+    // This is expected to fail currently if the bug exists
+    expect(finalStats.mode & 0o777).toBe(0o600);
+  });
+});


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Atomic writes in `sync` command reset file permissions to default (0o644) because `fs.rename` replaces metadata. This exposes sensitive `.env` files that were previously secured (0o600).
🎯 Impact: Sensitive environment variables could be exposed to other users on the system.
🔧 Fix: Preserved existing file mode during atomic write and enforced 0o600 default for new `.env` files.
✅ Verification: Added `tests/permission_test.ts` which verifies permissions are preserved.

---
*PR created automatically by Jules for task [621891489291593799](https://jules.google.com/task/621891489291593799) started by @atssj*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability where file permissions could be reset during sync operations. Configuration files now maintain proper permission settings.

* **Tests**
  * Added test coverage for file permission preservation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->