### PR TITLE
🛡️ Sentinel: Fix insecure file permissions in sync command

### DIFF
--- a/.env.test_perm
+++ b/.env.test_perm
@@ -1,0 +1,1 @@
+SECRET=updated

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Arbitrary File Overwrite via Symbolic Links (CWE-59) in `FileRestorer` and `restoreBackup`.
 **Learning:** Checking `fs.existsSync` follows symlinks, so it returns true for a symlink pointing to an existing file. Writing to this path overwrites the target file (e.g., `/etc/passwd`) instead of replacing the symlink.
 **Prevention:** Use `fs.lstatSync` to check if the target is a symbolic link. If so, unlink it (`fs.unlinkSync`) before writing the restored file to ensure the operation only affects the intended path.
+
+## 2026-02-01 - Permission Reset on Atomic Writes
+**Vulnerability:** Insecure File Permissions (CWE-276) during Atomic Write.
+**Learning:** The "Atomic Write" pattern (`write temp` + `rename`) replaces the original file with a new one created with default umask permissions (often 0644). This unintentionally makes sensitive files (previously 0600) readable by others.
+**Prevention:** Always `stat` the target file (if it exists) to capture its `mode` before creating the temporary file. Pass this `mode` to `fs.writeFileSync`. For new sensitive files, explicitly enforce restricted permissions (0600).


### PR DESCRIPTION
🛡️ Sentinel Security Fix: Insecure File Permissions during Atomic Write (CWE-276)

**Vulnerability:**
The `sync` command used an "atomic write" pattern (write to `.tmp` file, then `rename`) which failed to preserve the original file's permissions. This caused sensitive files (e.g., `.env`) that were restricted to `0600` (owner read/write) to be reset to the default umask permissions (often `0644` - readable by others) after a sync operation.

**Fix:**
- Modified `src/commands/sync.ts` to `stat` the target file (if it exists) and pass its `mode` to `fs.writeFileSync` when creating the temporary file.
- Added logic to default to `0o600` for new files matching the sensitive pattern (`.env*`, excluding `.env.example`).
- Documented the vulnerability pattern in `.jules/sentinel.md`.

**Verification:**
- Validated with a reproduction script that confirmed permissions were previously reset to `0644`.
- Validated with a verification script that confirmed permissions are now preserved as `0600`.
- Ran full test suite (`bun test`) to ensure no regressions.

---
*PR created automatically by Jules for task [3612794955894438784](https://jules.google.com/task/3612794955894438784) started by @atssj*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive configuration files are now created with restricted file permissions during sync operations.
  * Existing file permissions are preserved when syncing configuration files.

* **Documentation**
  * Added documentation regarding file permission security considerations for configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->