### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure file permissions in sync command

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Arbitrary File Overwrite via Symbolic Links (CWE-59) in `FileRestorer` and `restoreBackup`.
 **Learning:** Checking `fs.existsSync` follows symlinks, so it returns true for a symlink pointing to an existing file. Writing to this path overwrites the target file (e.g., `/etc/passwd`) instead of replacing the symlink.
 **Prevention:** Use `fs.lstatSync` to check if the target is a symbolic link. If so, unlink it (`fs.unlinkSync`) before writing the restored file to ensure the operation only affects the intended path.
+
+## 2026-02-14 - Permission Reset in Atomic Writes
+**Vulnerability:** Insecure File Permissions (CWE-276) in `sync` command.
+**Learning:** The atomic write pattern (`write temp` -> `rename`) replaces the original file with a new file (the temp file), which has default permissions (usually 0644/0666). This implicitly strips restricted permissions (0600) from sensitive files like `.env` during updates.
+**Prevention:** Explicitly capture the original file's mode using `fs.statSync` before writing the temp file, and apply that mode to the temp file using `fs.writeFileSync(..., { mode })` or `fs.chmodSync`. For new sensitive files, default to `0o600`.

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, beforeAll, afterAll, beforeEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+describe('env-twin CLI Permissions Security', () => {
+  const testDir = path.join(__dirname, 'test-perms-temp');
+  const indexScript = path.resolve(__dirname, '../src/index.ts');
+
+  beforeAll(() => {
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    // Clean
+    const files = fs.readdirSync(testDir);
+    for (const file of files) {
+      fs.rmSync(path.join(testDir, file), { recursive: true, force: true });
+    }
+  });
+
+  test('should preserve 0600 permissions when syncing existing sensitive files', () => {
+    if (process.platform === 'win32') return; // Skip on Windows
+
+    const envFile = path.join(testDir, '.env');
+    const localEnvFile = path.join(testDir, '.env.local');
+
+    // 1. Create .env with 0600
+    fs.writeFileSync(envFile, 'VAR1=value1\n', { mode: 0o600 });
+    // 2. Create .env.local with new key to trigger sync
+    fs.writeFileSync(localEnvFile, 'VAR2=value2\n', { mode: 0o600 });
+
+    const originalStat = fs.statSync(envFile);
+    expect(originalStat.mode & 0o777).toBe(0o600);
+
+    // 3. Run sync
+    try {
+        execSync(`bun ${indexScript} sync --yes`, { cwd: testDir });
+    } catch (e) {
+        console.error('Sync failed:', e);
+        throw e;
+    }
+
+    // 4. Check permissions of .env (it should have received VAR2)
+    const content = fs.readFileSync(envFile, 'utf-8');
+    expect(content).toContain('VAR2='); // Verify it was actually written to
+
+    const newStat = fs.statSync(envFile);
+    // Should still be 600
+    if ((newStat.mode & 0o777) !== 0o600) {
+        console.error(`Expected 0600 but got ${(newStat.mode & 0o777).toString(8)}`);
+    }
+    expect(newStat.mode & 0o777).toBe(0o600);
+
+    // Check .env.local (should have received VAR1)
+    const localContent = fs.readFileSync(localEnvFile, 'utf-8');
+    expect(localContent).toContain('VAR1=');
+
+    const localStat = fs.statSync(localEnvFile);
+    expect(localStat.mode & 0o777).toBe(0o600);
+  });
+});


### PR DESCRIPTION
This PR addresses a security vulnerability where the `sync` command was resetting file permissions of `.env` files to the system default (usually world-readable `0644`) during updates. This happened because the atomic write pattern (write to temp file, then rename) replaced the original file with a new file that didn't inherit the original's permissions.

**Changes:**
- Modified `src/commands/sync.ts` to check for the existing file's mode before writing the temporary file.
- If the file exists, its mode is applied to the temporary file.
- If the file is new and matches the sensitive pattern (`.env*` excluding `.env.example`), it defaults to `0o600` (restricted to owner).
- Added `tests/permissions.test.ts` to verify that `0600` permissions are preserved after a sync operation.

**Verification:**
- Ran `bun test` to ensure all tests pass, including the new regression test.
- Manual reproduction script confirmed the issue is resolved.

---
*PR created automatically by Jules for task [8538623523699621705](https://jules.google.com/task/8538623523699621705) started by @atssj*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file permission handling during sync to preserve existing permissions or assign secure permissions to newly created sensitive configuration files

* **Documentation**
  * Documented atomic write permission vulnerability and best practices for handling file permissions securely

* **Tests**
  * Added test suite to verify environment file permission preservation and proper handling during sync operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->