### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/atssj/env-twin/security/code-scanning/1](https://github.com/atssj/env-twin/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For a typical build-and-test workflow that only checks out code and runs builds/tests, `contents: read` is sufficient. This both enforces least privilege and documents the workflow’s security posture.

For this specific file, `.github/workflows/test.yml`, the simplest, non‑breaking change is to add a root‑level `permissions` block near the top of the file (e.g., after `name:` and before `on:`). This will apply to all jobs in the workflow (there is only `build-and-test`), and we can set it to `contents: read`, which matches the CodeQL recommendation and is consistent with the actions being performed (checkout, build, test). No other changes or imports are required.

Concretely:
- Edit `.github/workflows/test.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 1 (`name: Build and Test`) and line 3 (`on:`).  
This constrains `GITHUB_TOKEN` to read-only repository contents for this workflow and resolves the CodeQL finding without altering the workflow’s behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
